### PR TITLE
Safe invoke of git command

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -40,6 +40,11 @@ if (argv.dest) {
   dest = argv.dest;
 } else {
   var topLevel = gup.findGitRoot();
+  if (topLevel instanceof Error) {
+    console.error('fatal: ' + topLevel.message);
+    exit(1);
+  }
+  
   if (test('-f', topLevel + '/.git')) {
     // this is a sub module
     var buf = fs.readFileSync(topLevel + '/.git', "utf8").trim();
@@ -49,11 +54,6 @@ if (argv.dest) {
     dest = topLevel + '/hooks/';
   } else {
     dest = topLevel + '/.git/hooks/';
-  }
-
-  if (error()) {
-    console.error('fatal: Not a git repository (or any of the parent directories): .git');
-    exit(1);
   }
 }
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -2,7 +2,6 @@
 /* global error */
 'use strict';
 
-require('shelljs/global');
 var fs = require("fs");
 var gup = require('../');
 var yargs = require('yargs')
@@ -40,8 +39,7 @@ var dest;
 if (argv.dest) {
   dest = argv.dest;
 } else {
-  var topLevel = exec('git rev-parse --show-toplevel', { silent: true })
-    .output.slice(0, -1);
+  var topLevel = gup.findGitRoot();
   if (test('-f', topLevel + '/.git')) {
     // this is a sub module
     var buf = fs.readFileSync(topLevel + '/.git', "utf8").trim();

--- a/index.js
+++ b/index.js
@@ -27,6 +27,16 @@ var hooks = [
   'update'
 ];
 
+function findGitRoot() {
+  var gitRevParseTopLevel = exec('git rev-parse --show-toplevel');
+  if (gitRevParseTopLevel.code !== 0) {
+    console.error('guppy-cli needs a git repository to work with.');
+    return exit(1);
+  }
+
+  return gitRevParseTopLevel.output.slice(0, -1);
+}
+
 function install(hook, dest, cb) {
   cb = cb || dest;
 
@@ -74,5 +84,6 @@ function installAll(dest, cb) {
   );
 }
 
+module.exports.findGitRoot = findGitRoot;
 module.exports.install = install;
 module.exports.installAll = installAll;

--- a/index.js
+++ b/index.js
@@ -44,9 +44,7 @@ function install(hook, dest, cb) {
   if (typeof cb !== 'function') cb(new Error('Callback must be a function.'));
   if (hooks.indexOf(hook) === -1) cb(new Error('Invalid hook name.'));
 
-  dest = ((typeof dest === 'function' ? null : dest) ||
-    exec('git rev-parse --show-toplevel')
-      .output.slice(0, -1) + '/.git/hooks/');
+  dest = (typeof dest === 'function' ? null : dest) || findGitRoot() + '/.git/hooks/';
 
   var destHook = path.join(dest, hook);
 


### PR DESCRIPTION
Using `exec()` without any check of returned exit code makes the whole node process hang. A more real-world scenario is simply trying to run `guppy` in a directory that is not part of a git repository:

```
mkdir tmp
cd tmp
npm install guppy-cli
./node_modules/.bin/guppy pre-commit
# ... hangs
```

I introduced `findGitRoot()` helper to substitude the two `exec()` calls with a more advanced approach also checking the returned `.code` property.

Hence, this seems to be more an issue with `shelljs`?

Fixes #39 
